### PR TITLE
shuffle the pool on recycle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,5 +15,6 @@ jobs:
     - uses: jiro4989/setup-nim-action@v1
       with:
         nim-version: ${{ matrix.nim-version }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - run: nimble test --mm:orc -y
     - run: nimble test --threads:on --mm:orc -y

--- a/waterpark.nimble
+++ b/waterpark.nimble
@@ -1,6 +1,6 @@
-version     = "0.1.0"
+version     = "0.1.1"
 author      = "Ryan Oldenburg"
-description = "Thread-safe database connection pools"
+description = "Thread-safe object pools"
 license     = "MIT"
 
 srcDir = "src"


### PR DESCRIPTION
To avoid behavior that depends on the order of borrows, and to avoid uneven usage of pooled objects, the pool is shuffled each time an object is returned.