### PR TITLE
Make postgres `pool` public

### DIFF
--- a/src/waterpark/postgres.nim
+++ b/src/waterpark/postgres.nim
@@ -8,7 +8,7 @@ else:
 export db_postgres, borrow, recycle, items
 
 type PostgresPool* = object
-  pool*: Pool[DbConn]
+  pool: Pool[DbConn]
 
 proc close*(pool: PostgresPool) =
   ## Closes the database connections in the pool then deallocates the pool.

--- a/src/waterpark/postgres.nim
+++ b/src/waterpark/postgres.nim
@@ -8,7 +8,7 @@ else:
 export db_postgres, borrow, recycle, items
 
 type PostgresPool* = object
-  pool: Pool[DbConn]
+  pool*: Pool[DbConn]
 
 proc close*(pool: PostgresPool) =
   ## Closes the database connections in the pool then deallocates the pool.

--- a/src/waterpark/postgres.nim
+++ b/src/waterpark/postgres.nim
@@ -23,8 +23,6 @@ proc newPostgresPool*(
   size: int, connection, user, password, database: string
 ): PostgresPool =
   ## Creates a new thead-safe pool of Postgres database connections.
-  if size <= 0:
-    raise newException(CatchableError, "Invalid pool size")
   result.pool = newPool[DbConn]()
   try:
     for _ in 0 ..< size:


### PR DESCRIPTION
# Situation
Currently only the type `PostgresPool` is public, and when accessing the individual connections we are using `borrow`, and on return we `recycle` and `shuffle`.

# Purpose for the PR
When using prepared statements we need to initiate the statements for each connection. By making the `pool` public we can iterate over each connection to ensure, that prepared statements are initialized correctly.

# Example after PR
```nim
import ./waterpark/postgres

let pg = newPostgresPool(3, "localhost", "pguser", "dietcoke", "test")

for db in pg.pool.items():
  let p = prepare(db, "myExampleInsert", sql"""SELECT name FROM user WHERE id = $1""", 1)

pg.withConnection conn:
  echo getValue(db, "myExampleInsert".SqlPrepared, "4")
```

# Without the PR
Without the PR we need to keep track of each thread and if the prepared statements are initialized or implement an overhead and catch each error:
```nim
Error: unhandled exception: ERROR:  prepared statement "myExampleInsert" already exists
 [DbError]
```